### PR TITLE
Feature/urb 113 transaction manager support 1

### DIFF
--- a/packages/api/src/features/feed/repositories/feed-log-repository.ts
+++ b/packages/api/src/features/feed/repositories/feed-log-repository.ts
@@ -11,7 +11,7 @@ import {
   type FeedLogItemModel,
   type NewFeedLogItemModel,
 } from '@/features/feed/domain/feed-log-item'
-import { getPrismaClientInstance } from '@/lib/prisma/app-prisma-client'
+import { getTransactionManager } from '@/lib/prisma/transaction-manager'
 import type { CycleValue } from 'core/features/feed/feed'
 import { FEED_LOG_STATUS_VALUE_MAP } from 'core/features/feed/feed-logs'
 import { z } from 'zod'
@@ -21,7 +21,8 @@ export class FeedLogRepository {
    * 指定したIDのFeedLogを返す
    */
   async findById(feedLogId: string): Promise<FeedLogDetailModel> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     const loadedFeedLog = await prisma.feedLog.findFirst({
       where: {
@@ -76,7 +77,8 @@ export class FeedLogRepository {
   async findFeedLogsListItemModelsByFeedId(
     feedId: string,
   ): Promise<FeedLogListItemModel[]> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     const loadedFeedLogs = await prisma.feedLog.findMany({
       where: {
@@ -132,7 +134,8 @@ export class FeedLogRepository {
     pageSize: number,
     page = 1,
   ): Promise<{ count: number; items: FeedLogListItemModel[] }> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     const loadedFeedLogs = await prisma.feedLog.findMany({
       where: {
@@ -199,7 +202,8 @@ export class FeedLogRepository {
     userId: string,
     fromDate: Date,
   ): Promise<FeedLogListItemModel[]> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     const loadedFeedLogs = await prisma.feedLog.findMany({
       where: {
@@ -256,7 +260,8 @@ export class FeedLogRepository {
    * 処理が完了していないFeedLogの一覧を返す
    */
   async findPendingFeedLogs(): Promise<FeedLogListItemModel[]> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     const loadedFeedLogs = await prisma.feedLog.findMany({
       where: {
@@ -286,7 +291,8 @@ export class FeedLogRepository {
   }
 
   async save(feedLog: FeedLogDetailModel): Promise<void> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     await prisma.feedLog.upsert({
       where: {
@@ -320,7 +326,8 @@ export class FeedLogRepository {
   }
 
   async clearFeedLogItems(feedLogId: string): Promise<void> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     await prisma.feedLogItem.deleteMany({
       where: {
@@ -330,7 +337,8 @@ export class FeedLogRepository {
   }
 
   async saveFeedLogItems(items: NewFeedLogItemModel[]): Promise<void> {
-    const prisma = getPrismaClientInstance()
+    const transactionManager = getTransactionManager()
+    const prisma = transactionManager.getActivePrisma()
 
     const feedLogItemsPromises = items.map((item) =>
       prisma.feedLogItem.create({

--- a/packages/api/src/handlers/api-gateway/feed/actions/list-all-feed-log-action.ts
+++ b/packages/api/src/handlers/api-gateway/feed/actions/list-all-feed-log-action.ts
@@ -7,6 +7,7 @@ import {
   feedLogSearchResultModelSchema,
 } from '@/features/feed/domain/feed-log'
 import { FeedLogRepository } from '@/features/feed/repositories/feed-log-repository'
+import { getTransactionManager } from '@/lib/prisma/transaction-manager'
 
 export class ListUserFeedLogAction extends ActionDefinition<AppContext> {
   buildOpenApiAppRoute(parentApp: OpenAPIHono<AppContext>): void {
@@ -79,13 +80,16 @@ export class ListUserFeedLogAction extends ActionDefinition<AppContext> {
           return c.json({ error: 'Invalid page size' }, 400)
         }
 
-        const feedLogRepository = new FeedLogRepository()
+        const transactionManager = getTransactionManager()
         const { count, items: feedLogList } =
-          await feedLogRepository.findFeedLogsListItemModelsByUserId(
-            user.id,
-            pageSize,
-            currentPage,
-          )
+          await transactionManager.transaction(async () => {
+            const feedLogRepository = new FeedLogRepository()
+            return await feedLogRepository.findFeedLogsListItemModelsByUserId(
+              user.id,
+              pageSize,
+              currentPage,
+            )
+          })
 
         return c.json(
           feedLogSearchResultModelSchema.parse({

--- a/packages/api/src/handlers/step-functions/feed-analyzer/handlers/__tests__/create-feed-logs.test.ts
+++ b/packages/api/src/handlers/step-functions/feed-analyzer/handlers/__tests__/create-feed-logs.test.ts
@@ -6,87 +6,91 @@ import { GitHubApiClientStub } from '@/features/feed/services/github-api-client-
 import { swapGitHubApiClientForTest } from '@/features/feed/services/github-api-client'
 import { getPrismaClientInstance } from '@/lib/prisma/app-prisma-client'
 import type { RawGitHubReleaseListItem } from '@/features/feed/domain/github-release'
+import { withTransactionManager } from '@/lib/vitest/transaction-manager-helper'
 
 describe('createFeedLogs', () => {
-  test('初回は全てのリリースを対象にフィードを作成すること', async () => {
-    const feed = await FeedFactory.create({
-      url: 'https://github.com/owner/repo',
-    })
+  test(
+    '初回は全てのリリースを対象にフィードを作成すること',
+    withTransactionManager(async () => {
+      const feed = await FeedFactory.create({
+        url: 'https://github.com/owner/repo',
+      })
 
-    const githubReleaseListItems: RawGitHubReleaseListItem[] = [
-      {
-        id: 3,
-        name: 'v1.0.2',
-        tag_name: 'v1.0.2',
-        published_at: '2021-01-03T00:00:00Z',
-      },
-      {
-        id: 2,
-        name: 'v1.0.1',
-        tag_name: 'v1.0.1',
-        published_at: '2021-01-02T00:00:00Z',
-      },
-      {
-        id: 1,
-        name: 'v1.0.0',
-        tag_name: 'v1.0.0',
-        published_at: '2021-01-01T00:00:00Z',
-      },
-    ]
-    const stubGithubApiClient = new GitHubApiClientStub()
-    stubGithubApiClient.setReleaseResponse(githubReleaseListItems)
-    swapGitHubApiClientForTest(stubGithubApiClient)
+      const githubReleaseListItems: RawGitHubReleaseListItem[] = [
+        {
+          id: 3,
+          name: 'v1.0.2',
+          tag_name: 'v1.0.2',
+          published_at: '2021-01-03T00:00:00Z',
+        },
+        {
+          id: 2,
+          name: 'v1.0.1',
+          tag_name: 'v1.0.1',
+          published_at: '2021-01-02T00:00:00Z',
+        },
+        {
+          id: 1,
+          name: 'v1.0.0',
+          tag_name: 'v1.0.0',
+          published_at: '2021-01-01T00:00:00Z',
+        },
+      ]
+      const stubGithubApiClient = new GitHubApiClientStub()
+      stubGithubApiClient.setReleaseResponse(githubReleaseListItems)
+      swapGitHubApiClientForTest(stubGithubApiClient)
 
-    const response = await handler(feed.id, {} as Context)
+      const response = await handler(feed.id, {} as Context)
 
-    const filteredResponse = response.map((item) => {
-      return {
-        key: item.key,
-        name: item.title,
-        date: item.date,
-      }
-    })
+      const filteredResponse = response.map((item) => {
+        return {
+          key: item.key,
+          name: item.title,
+          date: item.date,
+        }
+      })
 
-    expect(filteredResponse).toEqual([
-      {
-        key: '1',
-        name: 'v1.0.0',
-        date: new Date('2021-01-01T00:00:00Z'),
-      },
-      {
-        key: '2',
-        name: 'v1.0.1',
-        date: new Date('2021-01-02T00:00:00Z'),
-      },
-      {
-        key: '3',
-        name: 'v1.0.2',
-        date: new Date('2021-01-03T00:00:00Z'),
-      },
-    ])
+      expect(filteredResponse).toEqual([
+        {
+          key: '1',
+          name: 'v1.0.0',
+          date: new Date('2021-01-01T00:00:00Z'),
+        },
+        {
+          key: '2',
+          name: 'v1.0.1',
+          date: new Date('2021-01-02T00:00:00Z'),
+        },
+        {
+          key: '3',
+          name: 'v1.0.2',
+          date: new Date('2021-01-03T00:00:00Z'),
+        },
+      ])
 
-    const prisma = getPrismaClientInstance()
-    const updatedFeed = await prisma.feed.findFirst({
-      where: {
-        id: feed.id,
-      },
-      include: {
-        feedGitHubMeta: true,
-        feedLogs: true,
-      },
-    })
+      const prisma = getPrismaClientInstance()
+      const updatedFeed = await prisma.feed.findFirst({
+        where: {
+          id: feed.id,
+        },
+        include: {
+          feedGitHubMeta: true,
+          feedLogs: true,
+        },
+      })
 
-    expect(
-      updatedFeed?.feedLogs?.length,
-      'feed_logsの登録件数が一致すること',
-    ).toBe(3)
-    expect(
-      updatedFeed?.feedGitHubMeta,
-      'feed_github_metasが登録されていること',
-    ).not.toBeNull()
-    expect(
-      updatedFeed?.feedGitHubMeta?.lastReleaseDate,
-      'latest_release_dateに最新のリリース日が記録されていること',
-    ).toEqual(new Date('2021-01-03T00:00:00Z'))
-  })
+      expect(
+        updatedFeed?.feedLogs?.length,
+        'feed_logsの登録件数が一致すること',
+      ).toBe(3)
+      expect(
+        updatedFeed?.feedGitHubMeta,
+        'feed_github_metasが登録されていること',
+      ).not.toBeNull()
+      expect(
+        updatedFeed?.feedGitHubMeta?.lastReleaseDate,
+        'latest_release_dateに最新のリリース日が記録されていること',
+      ).toEqual(new Date('2021-01-03T00:00:00Z'))
+    }),
+  )
 })

--- a/packages/api/src/handlers/step-functions/feed-analyzer/handlers/__tests__/enqueue-pending-feed-log-handler.test.ts
+++ b/packages/api/src/handlers/step-functions/feed-analyzer/handlers/__tests__/enqueue-pending-feed-log-handler.test.ts
@@ -1,42 +1,46 @@
 import { swapAnalyzeFeedLogQueueForTest } from '@/features/feed/services/analyze-feed-log-queue'
 import { AnalyzeFeedQueueStub } from '@/features/feed/services/analyze-feed-log-queue-stub'
 import { handler } from '@/handlers/step-functions/feed-analyzer/handlers/enqueue-pending-feed-log-handler'
+import { withTransactionManager } from '@/lib/vitest/transaction-manager-helper'
 import type { Context } from 'aws-lambda'
 import { FEED_LOG_STATUS_VALUE_MAP } from 'core/features/feed/feed-logs'
 import { FeedLogFactory } from 'prisma/seeds/feed-log-factory'
 import { describe, expect, test } from 'vitest'
 
 describe('enqueuePendingFeedLogHandler', () => {
-  test('wait, error状態のフィードログがキューに投入されること', async () => {
-    const analyzeFeedLogQueue = new AnalyzeFeedQueueStub()
+  test(
+    'wait, error状態のフィードログがキューに投入されること',
+    withTransactionManager(async () => {
+      const analyzeFeedLogQueue = new AnalyzeFeedQueueStub()
 
-    const waitingFeedLog = await FeedLogFactory.create({
-      status: FEED_LOG_STATUS_VALUE_MAP.WAIT,
-    })
-    await FeedLogFactory.create({
-      status: FEED_LOG_STATUS_VALUE_MAP.DONE,
-    })
-    await FeedLogFactory.create({
-      status: FEED_LOG_STATUS_VALUE_MAP.failed,
-    })
-    const erroredFeedLog = await FeedLogFactory.create({
-      status: FEED_LOG_STATUS_VALUE_MAP.ERROR,
-    })
+      const waitingFeedLog = await FeedLogFactory.create({
+        status: FEED_LOG_STATUS_VALUE_MAP.WAIT,
+      })
+      await FeedLogFactory.create({
+        status: FEED_LOG_STATUS_VALUE_MAP.DONE,
+      })
+      await FeedLogFactory.create({
+        status: FEED_LOG_STATUS_VALUE_MAP.failed,
+      })
+      const erroredFeedLog = await FeedLogFactory.create({
+        status: FEED_LOG_STATUS_VALUE_MAP.ERROR,
+      })
 
-    swapAnalyzeFeedLogQueueForTest(analyzeFeedLogQueue)
+      swapAnalyzeFeedLogQueueForTest(analyzeFeedLogQueue)
 
-    await handler(undefined, {} as Context)
+      await handler(undefined, {} as Context)
 
-    // 順序を意識しないためSetで比較
-    expect(new Set(analyzeFeedLogQueue.getMessages())).toEqual(
-      new Set([
-        {
-          feedLogId: waitingFeedLog.id,
-        },
-        {
-          feedLogId: erroredFeedLog.id,
-        },
-      ]),
-    )
-  })
+      // 順序を意識しないためSetで比較
+      expect(new Set(analyzeFeedLogQueue.getMessages())).toEqual(
+        new Set([
+          {
+            feedLogId: waitingFeedLog.id,
+          },
+          {
+            feedLogId: erroredFeedLog.id,
+          },
+        ]),
+      )
+    }),
+  )
 })

--- a/packages/api/src/handlers/step-functions/feed-analyzer/handlers/__tests__/notify-update-handler.test.ts
+++ b/packages/api/src/handlers/step-functions/feed-analyzer/handlers/__tests__/notify-update-handler.test.ts
@@ -4,24 +4,45 @@ import { UserFactory } from 'prisma/seeds/user-factory'
 import { vi, describe, expect, test, beforeEach, afterEach } from 'vitest'
 import { handler } from '../notify-update-handler'
 import { getPrismaClientInstance } from '@/lib/prisma/app-prisma-client'
+import { withTransactionManager } from '@/lib/vitest/transaction-manager-helper'
 
 describe('NotifyUpdateHandler', () => {
-  test('初回は24時間以内に作成されたFeedLogを対象とすること', async () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
+  test(
+    '初回は24時間以内に作成されたFeedLogを対象とすること',
+    withTransactionManager(async () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+      })
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
+      afterEach(() => {
+        vi.useRealTimers()
+      })
 
-    const user = await UserFactory.create()
-    const testNow = new Date('2025-01-02T00:00:00+0900')
-    vi.setSystemTime(testNow)
+      const user = await UserFactory.create()
+      const testNow = new Date('2025-01-02T00:00:00+0900')
+      vi.setSystemTime(testNow)
 
-    // それぞれのFeedLogに別々のFeedを割り当てる
-    for (let i = 0; i < 2; i++) {
-      const feed = await FeedFactory.create({
+      // それぞれのFeedLogに別々のFeedを割り当てる
+      for (let i = 0; i < 2; i++) {
+        const feed = await FeedFactory.create({
+          user: {
+            connect: {
+              id: user.id,
+            },
+          },
+        })
+        await FeedLogFactory.create({
+          feed: {
+            connect: {
+              id: feed.id,
+            },
+          },
+          createdAt: new Date('2025-01-01 00:00:00+0900'), // ギリギリ24時間以内
+        })
+      }
+
+      // 24時間以上前のFeedLogを作成
+      const oldFeed = await FeedFactory.create({
         user: {
           connect: {
             id: user.id,
@@ -31,116 +52,102 @@ describe('NotifyUpdateHandler', () => {
       await FeedLogFactory.create({
         feed: {
           connect: {
-            id: feed.id,
+            id: oldFeed.id,
           },
         },
-        createdAt: new Date('2025-01-01 00:00:00+0900'), // ギリギリ24時間以内
+        createdAt: new Date('2024-12-31 23:59:59+0900'),
       })
-    }
 
-    // 24時間以上前のFeedLogを作成
-    const oldFeed = await FeedFactory.create({
-      user: {
-        connect: {
-          id: user.id,
+      // 通知作成処理の実行
+      await handler({})
+
+      const prisma = getPrismaClientInstance()
+      const notifications = await prisma.notification.findMany({
+        where: {
+          userId: user.id,
         },
-      },
-    })
-    await FeedLogFactory.create({
-      feed: {
-        connect: {
-          id: oldFeed.id,
+        include: {
+          notificationItems: true,
         },
-      },
-      createdAt: new Date('2024-12-31 23:59:59+0900'),
-    })
+      })
 
-    // 通知作成処理の実行
-    await handler({})
+      expect(notifications.length, 'お知らせ全体は1件であること').toBe(1)
+      expect(
+        notifications[0].notificationItems.length,
+        'お知らせの内容は今日作成されたFeedLogであること',
+      ).toBe(2)
+    }),
+  )
 
-    const prisma = getPrismaClientInstance()
-    const notifications = await prisma.notification.findMany({
-      where: {
-        userId: user.id,
-      },
-      include: {
-        notificationItems: true,
-      },
-    })
+  test(
+    '2回目は1回目以降に作成されたFeedLogを対象とすること',
+    withTransactionManager(async () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+      })
 
-    expect(notifications.length, 'お知らせ全体は1件であること').toBe(1)
-    expect(
-      notifications[0].notificationItems.length,
-      'お知らせの内容は今日作成されたFeedLogであること',
-    ).toBe(2)
-  })
+      afterEach(() => {
+        vi.useRealTimers()
+      })
 
-  test('2回目は1回目以降に作成されたFeedLogを対象とすること', async () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
+      const user = await UserFactory.create()
+      const testNow = new Date('2025-01-02T00:00:00+0900')
+      vi.setSystemTime(testNow)
 
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
-    const user = await UserFactory.create()
-    const testNow = new Date('2025-01-02T00:00:00+0900')
-    vi.setSystemTime(testNow)
-
-    const feed = await FeedFactory.create({
-      user: {
-        connect: {
-          id: user.id,
+      const feed = await FeedFactory.create({
+        user: {
+          connect: {
+            id: user.id,
+          },
         },
-      },
-    })
-    for (let i = 0; i < 2; i++) {
+      })
+      for (let i = 0; i < 2; i++) {
+        await FeedLogFactory.create({
+          feed: {
+            connect: {
+              id: feed.id,
+            },
+          },
+          createdAt: new Date('2025-01-01 15:00:00+0900'),
+        })
+      }
+
+      // 1回目の実行。
+      await handler({})
+
+      // 時間を少し進めてフィードログを作成
+      vi.setSystemTime('2025-01-02T10:00:00+0900')
+
       await FeedLogFactory.create({
         feed: {
           connect: {
             id: feed.id,
           },
         },
-        createdAt: new Date('2025-01-01 15:00:00+0900'),
+        createdAt: new Date(),
       })
-    }
 
-    // 1回目の実行。
-    await handler({})
+      // 2回目の実行
+      await handler({})
 
-    // 時間を少し進めてフィードログを作成
-    vi.setSystemTime('2025-01-02T10:00:00+0900')
-
-    await FeedLogFactory.create({
-      feed: {
-        connect: {
-          id: feed.id,
+      // 最後に作成されたお知らせを1件取得
+      const prisma = getPrismaClientInstance()
+      const latestNotification = await prisma.notification.findFirst({
+        where: {
+          userId: user.id,
         },
-      },
-      createdAt: new Date(),
-    })
+        include: {
+          notificationItems: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      })
 
-    // 2回目の実行
-    await handler({})
-
-    // 最後に作成されたお知らせを1件取得
-    const prisma = getPrismaClientInstance()
-    const latestNotification = await prisma.notification.findFirst({
-      where: {
-        userId: user.id,
-      },
-      include: {
-        notificationItems: true,
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    })
-
-    expect(
-      latestNotification?.notificationItems.length,
-      '最新のお知らせの内容は1回目の後で作成されたFeedLogであること',
-    ).toBe(1)
-  })
+      expect(
+        latestNotification?.notificationItems.length,
+        '最新のお知らせの内容は1回目の後で作成されたFeedLogであること',
+      ).toBe(1)
+    }),
+  )
 })

--- a/packages/api/src/lib/vitest/transaction-manager-helper.ts
+++ b/packages/api/src/lib/vitest/transaction-manager-helper.ts
@@ -1,0 +1,5 @@
+import { runWithTransactionManager } from '@/lib/prisma/transaction-manager'
+
+export function withTransactionManager(callback: () => Promise<void>) {
+  return () => runWithTransactionManager(async () => callback())
+}


### PR DESCRIPTION
<!-- GitHub Copilot Review への指示： このPRのレビューコメントは日本語でお願いします。スタイルガイドは /.gemini/styleguide.md を参照してください -->

## 変更内容
- ダッシュボードで発行するクエリがトランザクション内で行われるように変更
  - Prismaがクエリ単位でbegin/commitを発行し、各クエリに100msec程度かかっていることへの対処

![image](https://github.com/user-attachments/assets/89a0c883-4f0c-40f5-ae7e-6c9a962936cf)


## 関連するIssue

- URB-113

## スクリーンショット（必要な場合）

変更の視覚的な説明が必要な場合は、ここにスクリーンショットを追加してください。
